### PR TITLE
Fix README date typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ As an example, a sample file with the following data:
 </tr>
 <tr>
   <td>
-    14/5/2016
+    14/11/2016
   </td>
   <td>
     5


### PR DESCRIPTION
Fix the README typo found by a candidate.

![typo-payroll-sample](https://cloud.githubusercontent.com/assets/430293/25588801/dd30b4fe-2e77-11e7-8652-b52f7bbb7611.png)

from the candidate

> it says 14/5/2016 in the input, but the output doesn’t contain anything for May. Instead it adds up to $300 (10*$20 + 5*$20) for November for Employee 1. I think it should say 14/11/2016. Right?
